### PR TITLE
Top-Button redirects to List-View

### DIFF
--- a/netbox_attachments/templates/netbox_attachments/add_attachment_button.html
+++ b/netbox_attachments/templates/netbox_attachments/add_attachment_button.html
@@ -1,5 +1,5 @@
 {% if perms.netbox_attachments.add_netboxattachment %}
-    <a href="{% url 'plugins:netbox_attachments:netboxattachment_add' %}?object_type={{ object|content_type_id }}&object_id={{ object.pk }}&return_url={{ object.get_absolute_url }}"
+    <a href="{% url 'plugins:netbox_attachments:netboxattachment_add' %}?object_type={{ object|content_type_id }}&object_id={{ object.pk }}&return_url={% url object_type_attachment_list pk=object.pk %}"
        class="btn btn-secondary">
         <i class="mdi mdi-paperclip" aria-hidden="true"></i>
         Add Attachment


### PR DESCRIPTION
Change the redirect target of the top "Add Attachment" button from the url you are currently at to the attachment list view of the object where the attachment will/was created. This makes it consistent with for example the "Add Component" buttons for devices.

The implementation is probably not perfect, I was mostly playing around to see if/how it can be done. It uses the fact that registering a view also always creates a matching url-pattern. The name of that url-pattern is [predictably derived](https://github.com/netbox-community/netbox/blob/v4.4.4/netbox/utilities/urls.py#L44) from the view name, and can then be passed to Django's `url` template function (together with the primary key of the object).

It would have actually been easier if the view name wouldn't also include the model name again and just be a constant string (like `attachments`). This would also make the URLs look a bit nicer, instead of `/dcim/devices/1234/device-attachment_list/` you get `/dcim/devices/1234/attachments/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * After adding an attachment, users are redirected to the attachment list for that object instead of back to the object's page.

* **Refactor**
  * Internal flow for registering attachment tab views and generating the "add attachment" button was unified so the tab and button now use a single, consistent URL pattern, reducing mismatches and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->