### PR TITLE
Revert: Docs and comment accuracy pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ CLAUDE.md
 .claude/hooks/
 .claude/agents/
 .claude/
-docs/agents/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,11 +6,11 @@ Configure plugin settings under `PLUGINS_CONFIG["netbox_attachments"]`.
 
 These were replaced in v7.1.0 and are **ignored** if still present:
 
-| Removed | Use instead | Check ID |
-| --- | --- | --- |
-| `apps` | `scope_filter` | `netbox_attachments.W001` |
-| `allowed_models` | `scope_filter` | `netbox_attachments.W002` |
-| `mode` | `applied_scope` (values are `app`/`model`, not `permissive`/`restrictive`) | `netbox_attachments.W003` |
+| Removed | Use instead |
+| --- | --- |
+| `apps` | `scope_filter` |
+| `allowed_models` | `scope_filter` |
+| `mode` | `applied_scope` (values are `app`/`model`, not `permissive`/`restrictive`) |
 
 NetBox keeps unrecognized keys in `PLUGINS_CONFIG` without reading them, so a stale config does not raise an error — the replacement setting silently falls back to its default instead. Because that default already covers several core apps, part of the configuration keeps working while the rest does not, which is easy to mistake for a bug in the plugin.
 
@@ -18,12 +18,6 @@ Since v11.3.0 a Django system check warns about each removed setting at startup.
 
 ```bash
 python3 manage.py check
-```
-
-The check IDs above are stable and will not be renumbered. Deleting the stale key is the correct fix, but if you must keep it, silence the warning in `configuration.py`:
-
-```python
-SILENCED_SYSTEM_CHECKS = ["netbox_attachments.W001"]
 ```
 
 ## Settings
@@ -69,7 +63,7 @@ Default display location for attachment UI. Each value controls where the panel 
 - `full_width_page` — injects the panel as a full-width section below the main content.
 
 !!! warning
-    An unrecognized value matches none of the four render positions, so no attachment UI appears at all for the affected models — no tab, no panel. There is no error or warning. Use only the four values listed above.
+    Unrecognized values for `display_default` will silently produce a non-functional panel extension. Use only the four values listed above.
 
 ### `create_add_button`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,17 +4,17 @@
 
 ### Object detail attachment tab
 
-Open a supported NetBox object detail page. The attachment tab shows a table of all assignments for that object, rendered using `NetBoxAttachmentForObjectTable`. Columns shown by default: Attachment (link), Description, Size, Links, Tags, Created, and Actions. A **File** column is also available and can be enabled through the table's column selector.
+Open a supported NetBox object detail page. The attachment tab shows a table of all assignments for that object, rendered using `NetBoxAttachmentForObjectTable` with the following columns: Attachment (link), Description, File, Size, Links, and Actions (download and Unlink).
 
 The **Links** column shows the total number of objects this attachment is assigned to across the whole system, as a clickable number linking to the attachment detail page. A count of 1 means unlinking will leave the attachment with no assignments; a count greater than 1 means the attachment remains linked elsewhere.
 
-The Actions column holds a Download button plus the standard NetBox actions dropdown. Choosing **Delete** there removes only that assignment — the attachment and its file on disk are kept, so the effect is an unlink. Below the table, two buttons are available: "Add Attachment" (upload and assign a new file) and "Link Existing" (assign an already-uploaded attachment).
+Each row includes an Unlink button to remove that assignment without deleting the underlying file. Below the table, two buttons are available: "Add Attachment" (upload and assign a new file) and "Link Existing" (assign an already-uploaded attachment).
 
 Display location of the tab depends on the `display_default` and `display_setting` configuration options.
 
 ### Panel display modes (left_page, right_page, full_width_page)
 
-When the display mode is `left_page`, `right_page`, or `full_width_page`, the attachment UI is injected as an inline panel on the object detail page. The panel renders the same `NetBoxAttachmentForObjectTable` as the tab view, scoped to that object's assignments — including the Download button and the Delete action described above.
+When the display mode is `left_page`, `right_page`, or `full_width_page`, the attachment UI is injected as an inline panel on the object detail page. The panel renders the same `NetBoxAttachmentForObjectTable` as the tab view: each row includes a Download button and an Unlink button scoped to that object's assignments.
 
 The panel header contains "Add Attachment" and "Link Existing" buttons identical to those in the tab view. The table is loaded via HTMX from the dedicated `netboxattachment_panel_list` endpoint (`/plugins/netbox-attachments/netbox-attachment-panel/`), which filters assignments by `object_type_id` and `object_id`.
 

--- a/netbox_attachments/checks.py
+++ b/netbox_attachments/checks.py
@@ -6,7 +6,7 @@ Warns about settings that were removed in v7.1.0 when ``apps`` and
 keys, so a removed setting is not an error: it survives untouched in
 ``PLUGINS_CONFIG`` while nothing reads it, and the replacement silently falls
 back to its default. That default covers several core apps, so part of the
-configuration keeps working and the rest fails without a clue.
+configuration keeps working and the rest fails without a clue (issue #110).
 """
 
 from django.core.checks import Warning, register
@@ -17,9 +17,8 @@ from netbox_attachments.version import __version__
 _MERGED_HINT = "'apps' and 'allowed_models' were merged, so combine both into the single 'scope_filter' list."
 
 # Removed setting -> (replacement, stable check ID, extra hint).
-# The IDs are a published contract (docs/configuration.md, CHANGELOG, and any
-# user's SILENCED_SYSTEM_CHECKS): never renumber or reuse one, even if an entry
-# is dropped from this table.
+# The IDs are a published contract (CHANGELOG, SILENCED_SYSTEM_CHECKS): never
+# renumber or reuse one, even if an entry is dropped from this table.
 # `mode` is not a pure rename — its values changed along with its name.
 REMOVED_SETTINGS = {
     "apps": ("scope_filter", "netbox_attachments.W001", _MERGED_HINT),

--- a/netbox_attachments/templates/netbox_attachments/netboxattachment_list.html
+++ b/netbox_attachments/templates/netbox_attachments/netboxattachment_list.html
@@ -1,6 +1,7 @@
 {% extends 'generic/object_list.html' %}
+
 {% block head %}
-    <style>
+<style>
 /* Use rgba with --tblr-danger-rgb (214,57,57 in both modes) so a single rule
    handles light and dark mode — semi-transparency blends naturally against any
    table background without needing [data-bs-theme=dark] overrides. */
@@ -15,5 +16,5 @@
     --tblr-table-hover-bg:      rgba(var(--tblr-danger-rgb), 0.22);
     --tblr-table-hover-color:   inherit;
 }
-    </style>
+</style>
 {% endblock %}

--- a/netbox_attachments/tests/conftest.py
+++ b/netbox_attachments/tests/conftest.py
@@ -8,9 +8,9 @@ def fake_model(app_label: str, model_name: str):
     A stand-in model class whose _meta mirrors every attribute production code reads.
 
     One definition on purpose: when the code under test starts reading a new _meta
-    attribute, it is added here once instead of being chased through per-file
-    copies. Call it for a class, call the result for an instance:
-    fake_model("dcim", "device")().
+    attribute (as label_lower was added in #111), it is added here once instead of
+    being chased through per-file copies. Call it for a class, call the result for
+    an instance: fake_model("dcim", "device")().
     """
     return type(
         "FakeModel",

--- a/netbox_attachments/tests/test_checks.py
+++ b/netbox_attachments/tests/test_checks.py
@@ -24,7 +24,7 @@ def test_no_warnings_when_plugin_unconfigured(monkeypatch):
 
 
 def test_apps_setting_warns_and_names_replacement(monkeypatch):
-    """'apps' is silently ignored without this check."""
+    """The config from issue #110: 'apps' is silently ignored without this check."""
     monkeypatch.setattr(
         checks,
         "_get_plugin_settings",

--- a/netbox_attachments/tests/test_new_features.py
+++ b/netbox_attachments/tests/test_new_features.py
@@ -28,7 +28,7 @@ _VIEWS_PY = _ROOT / "views.py"
 
 
 # ===========================================================================
-# Feature 1 — Templates: Unlink confirmation object label
+# Feature 1 — Issue 3: Unlink confirmation template fix
 # ===========================================================================
 
 
@@ -76,7 +76,7 @@ def test_content_type_str_differs_from_app_label_model_format():
 
 
 # ===========================================================================
-# Feature 2 — Views: Object-detail attachment tab get_children() logic
+# Feature 2 — Issue 4: Object-detail attachment tab get_children() logic
 # ===========================================================================
 
 
@@ -155,7 +155,7 @@ def test_get_children_returns_prefetched_queryset():
 
 
 # ===========================================================================
-# Feature 3 — Forms: Assignment filter form field names
+# Feature 3 — Issue 2: Assignment filter form field names
 # ===========================================================================
 
 

--- a/netbox_attachments/utils.py
+++ b/netbox_attachments/utils.py
@@ -22,7 +22,14 @@ def _get_plugin_settings():
 
 
 def choice_default(value, choices, default=None):
-    """Return value if it is among choices, else default."""
+    """
+    Return the given value if it is among the allowed choices, or return the default value.
+
+    Checks if the provided value exists in the collection of choices. If found, the value is returned;
+    otherwise, the specified default (or None if not provided) is returned.
+    """
+
+    # Return value only if present in choices, else return default value
     if value not in choices:
         return default
     return value
@@ -30,14 +37,23 @@ def choice_default(value, choices, default=None):
 
 def attachment_upload(instance, filename):
     """
-    Build an attachment's upload path under the fixed "netbox-attachments/" prefix.
+    Generate a file upload path for an attachment.
 
-    An instance name that differs from the uploaded filename renames the file, keeping
-    the original extension(s).
+    Constructs an upload path using a fixed directory prefix ("netbox-attachments/") and
+    the filename. If the provided filename differs from the instance's name, the filename
+    is updated to match the instance's name while preserving its original file extension(s).
+
+    Args:
+        instance: A model instance with a 'name' attribute.
+        filename: The original filename; its extension(s) are preserved if a rename is applied.
+
+    Returns:
+        A string representing the formatted file upload path.
     """
     path = "netbox-attachments/"
 
     if instance.name and instance.name != filename:
+        # Rename the file to the provided name, if any. Attempt to preserve the file extension.
         extension = "".join(Path(filename).suffixes)
         filename = "".join([Path(instance.name).name, extension])  # strip dir components
 
@@ -46,10 +62,17 @@ def attachment_upload(instance, filename):
 
 def is_custom_object_model(model):
     """
-    True for a netbox_custom_objects dynamic model.
+    Determines if a model is a NetBox Custom Objects dynamic model.
 
-    CustomObject subclasses only, which excludes the plugin's own metadata models
-    (CustomObjectType, CustomObjectTypeField, ...) living in the same app.
+    Checks if the model is from the netbox_custom_objects app and inherits
+    from the CustomObject base class. This excludes the plugin's metadata
+    models like CustomObjectType, CustomObjectTypeField, etc.
+
+    Args:
+        model: A Django model class
+
+    Returns:
+        bool: True if this is a custom object model, False otherwise
     """
     if model._meta.app_label != "netbox_custom_objects":
         return False
@@ -103,12 +126,24 @@ def _resolve_custom_object_identifier(model):
 
 def validate_object_type(model):
     """
-    Whether the model is permitted to have attachments, per scope_filter/applied_scope.
+    Determines if a Django model is permitted to have attachments.
 
-    In 'model' scope the filter is mixed: a bare app label ('dcim') enables every model in
-    that app, an exact identifier ('dcim.device') enables only that one. Custom objects are
-    matched by their CustomObjectType name, not their generated class name — see
-    custom_object_identifier.
+    This function uses a unified filtering approach for both standard models and custom objects.
+    It checks the model against the plugin's scope_filter configuration.
+
+    For custom objects, the function uses CustomObjectType names in the format:
+    'netbox_custom_objects.{CustomObjectType.name}' (e.g., 'netbox_custom_objects.attachment')
+
+    When applied_scope='model', the function supports mixed mode filtering:
+    - App label entries (e.g., 'dcim') enable ALL models from that app
+    - Specific model entries (e.g., 'dcim.device') enable only that model
+
+    Args:
+        model: A Django model class or instance with a _meta attribute that contains
+               'app_label' and 'model_name'.
+
+    Returns:
+        bool: True if the model is allowed to have attachments; False otherwise.
     """
     plugin_settings = _get_plugin_settings()
     applied_scope = choice_default(plugin_settings.get("applied_scope"), ("app", "model"), "app")


### PR DESCRIPTION
Reverts 1783f48, 30739f0 and 3d4b728 so the change can land through a reviewable pull request instead of direct pushes to main.

No net effect intended. The follow-up PR re-applies the identical tree.
